### PR TITLE
Update canasta image version

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,7 +10,7 @@ version: '3.7'
 services:
   #db:
   web:
-    image: ghcr.io/canastawiki/canasta:1.0.1
+    image: ghcr.io/canastawiki/canasta:1.1.0
   #elasticsearch:
   #caddy:
   #varnish:


### PR DESCRIPTION
The older version has references to ```user-extensions``` and ```user-skins``` which conflicts with the path mentioned in the volumes section of the current docker-compose.yml file