### PR TITLE
removed link in web service as the db alias is provided by the default network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
     depends_on:
       - db
       - elasticsearch
-    links:
-      - db
     environment:
       # Sourced from .env
       - MW_SITE_SERVER=${MW_SITE_SERVER:-http://localhost}


### PR DESCRIPTION
the link seems to no longer be need as the alias is now created by the named network that is created on the initialization of the docker-compose