### PR TITLE
add maintenance container

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,7 @@ services:
   #db:
   web:
     image: ghcr.io/canastawiki/canasta:1.3.0
+  # maintenance:
   #elasticsearch:
   #caddy:
   #varnish:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
   web:
     image: ghcr.io/canastawiki/canasta:latest
     restart: unless-stopped
+    init: true
     extra_hosts:
       - "gateway.docker.internal:host-gateway"
     depends_on:
@@ -71,6 +72,30 @@ services:
     volumes:
       - caddy-data:/data
       - ./config/Caddyfile:/etc/caddy/Caddyfile
+
+  maintenance:
+    image: ghcr.io/canastawiki/canasta-maintenance:latest
+    restart: unless-stopped
+    init: true
+    extra_hosts:
+      - "gateway.docker.internal:host-gateway"
+    depends_on:
+      - db
+      - elasticsearch
+    environment:
+      # Sourced from .env
+      - MW_SITE_SERVER=${MW_SITE_SERVER:-http://localhost}
+      - PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE:-10M}
+      - PHP_POST_MAX_SIZE=${PHP_UPLOAD_MAX_FILESIZE:-10M}
+      - PHP_MAX_INPUT_VARS=${PHP_MAX_INPUT_VARS:-1000}
+      - MW_SITEMAP_SUBDIR
+      - MW_SITEMAP_IDENTIFIER
+    volumes:
+      - ./extensions:/var/www/mediawiki/w/user-extensions
+      - ./skins:/var/www/mediawiki/w/user-skins
+      - ./config:/mediawiki/config
+      - ./images:/mediawiki/images
+      - sitemap:/mediawiki/sitemap
 
   varnish:
     image: docker.io/library/varnish:7.0.2-alpine


### PR DESCRIPTION
Related issue [Canasta#33](https://github.com/CanastaWiki/Canasta/issues/33)
Related PRs [Canasta-Maintenance#1](https://github.com/CanastaWiki/Canasta-Maintenance/pull/1), [Canasta#266](https://github.com/CanastaWiki/Canasta/pull/226) 
This PR adds a separate container to run maintenance script for MediaWiki installation
## changes
- Added a `maintenance` container in the docker-compose

## testing
I have tested the changes made by importing an existing wiki as well as creating a new one

![brave_03-28-23(18-53-333)](https://user-images.githubusercontent.com/96643110/228255548-d06f54b3-1eab-4c7e-97e6-0dddfa79bd8d.png)

![brave_03-28-23(18-53-062)](https://user-images.githubusercontent.com/96643110/228255583-f3f9beeb-5121-434a-bdd8-546a9279621d.png)

PS- to locally test please edit the `docker-compose.override.yml` to point to the local images as there is no image in registry for the maintenance container
