### PR TITLE
Removes image from docker-compose.override.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,10 +7,10 @@ version: '3.7'
 # Only edits to docker-compose.override.yml are officially supported by Canasta.
 #
 # Uncomment the commented services and add lines below them if you would like to make additional customizations to them.
-services:
+#services:
   #db:
-  web:
-    image: ghcr.io/canastawiki/canasta:1.3.0
+  #web:
+  #  image: ghcr.io/canastawiki/canasta:1.3.0
   #elasticsearch:
   #caddy:
   #varnish:


### PR DESCRIPTION
The fact that `docker-compose.override.yml` contains an override for the `web` service `image` property may be confusing because the override file is loaded automatically by the Compose and thus until removed or commented out, if left untouched the stack will always try to load version `1.3.0` of the image regardless of the `image` property value at `docker-compose.yml` file.

I'd suggest keeping the override file in place, but commenting all the overrides out from it