### PR TITLE
Remove all extensions and skins from composer.local.json

### DIFF
--- a/config/composer.local.json
+++ b/config/composer.local.json
@@ -1,17 +1,5 @@
 {
 	"require": {
-		"mediawiki/chameleon-skin": "~4.0",
-		"mediawiki/maps": "10.0.0",
-		"mediawiki/mermaid": "~3.1",
-		"mediawiki/semantic-media-wiki": "4.1.1",
-		"mediawiki/semantic-result-formats": "4.0.2",
-		"mediawiki/semantic-breadcrumb-links": "2.1.x-dev",
-		"mediawiki/semantic-compound-queries": "~2.2",
-		"mediawiki/semantic-extra-special-properties": "3.0.2",
-		"mediawiki/semantic-scribunto": "2.2.0",
-		"mediawiki/simple-batch-upload": "1.8.2",
-		"mediawiki/bootstrap-components": "^5.0",
-		"mediawiki/sub-page-list": "2.0.2"
 	},
 	"extra": {
 		"merge-plugin": {


### PR DESCRIPTION
This change should happen concurrently with https://github.com/CanastaWiki/Canasta/pull/280 .

The plan is to download all skins and "real" extensions via Git and not Composer, with the idea that Composer should only be used to download required libraries, and "library extensions" like DataValues, ParserHooks and Bootstrap. (Plus any extensions that the admin wants to add.)