### PR TITLE
Gitignore images folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /config/*
 /extensions/*
 /skins/*
+/images/*


### PR DESCRIPTION
Other runtime data folders/volumes for the web container are ignored, but this one was not yet added to the gitignore