### PR TITLE
Make HTTP port configurable via HTTP_PORT environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+HTTP_PORT=80
 HTTPS_PORT=443
 MYSQL_PASSWORD=mediawiki
 MW_SITE_SERVER=https://localhost

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,6 @@ services:
   #elasticsearch:
   caddy:
       ports:
-      - "80:80"
+      - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"
   #varnish:


### PR DESCRIPTION
## Summary
- Add `HTTP_PORT` environment variable to make the HTTP port configurable
- Update `docker-compose.override.yml` to use `${HTTP_PORT:-80}:80`

## Problem
The HTTPS port was already configurable via `HTTPS_PORT`, but the HTTP port was hardcoded to 80 in `docker-compose.override.yml`. This made it impossible to run multiple Canasta instances on the same machine without port conflicts on port 80.

## Solution
This change makes `HTTP_PORT` configurable in `.env` (defaulting to 80), matching the existing pattern for `HTTPS_PORT`. 

Changes:
1. Added `HTTP_PORT=80` to `.env.example`
2. Updated `docker-compose.override.yml` to use `${HTTP_PORT:-80}:80`

## Usage
Users can now run multiple Canasta instances on the same machine by using different port combinations in their `.env` file:

```env
# Instance 1 (default)
HTTP_PORT=80
HTTPS_PORT=443
MW_SITE_SERVER=https://localhost

# Instance 2 (alternate ports)
HTTP_PORT=8080
HTTPS_PORT=8443
MW_SITE_SERVER=https://localhost:8443
```

## Related PR
- See also: CanastaWiki/CanastaBase#52 - Fixes `$wgServer` to include port number when running on non-standard ports (required for correct URL generation)