### PR TITLE
Use CANASTA_IMAGE environment variable for web service image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./my.cnf:/etc/my.cnf
 
   web:
-    image: ghcr.io/canastawiki/canasta:latest
+    image: ${CANASTA_IMAGE:-ghcr.io/canastawiki/canasta:latest}
     restart: unless-stopped
     extra_hosts:
       - "gateway.docker.internal:host-gateway"


### PR DESCRIPTION
Change the web service image from a hardcoded registry reference to use an environment variable with a default fallback:

  image: ${CANASTA_IMAGE:-ghcr.io/canastawiki/canasta:latest}

This allows the Canasta CLI to override the image when building from local source with the --build-from flag. The CLI sets CANASTA_IMAGE in the .env file to point to the locally built image (e.g., canasta:local).

When CANASTA_IMAGE is not set, the default behavior remains unchanged, pulling from the GitHub Container Registry.

Related PRs:
* CanastaWiki/Canasta-CLI#140
* CanastaWiki/CanastaBase#54
* CanastaWiki/Canasta#571
* CanastaWiki/Canasta-DockerCompose#73
* CanastaWiki/Canasta-Documentation#22