### PR TITLE
Add default skin setting to 30-Vector.php

### DIFF
--- a/config/settings/global/30-Vector.php
+++ b/config/settings/global/30-Vector.php
@@ -1,4 +1,6 @@
 <?php
-// Load the Vector skin - this is a default Canasta file
-// To not have Vector installed, simply delete this file.
+// Load the Vector skin and set it as the default.
+// This is a default Canasta file. To not have Vector installed,
+// simply delete this file.
+$wgDefaultSkin = "vector-2022";
 wfLoadSkin( 'Vector' );


### PR DESCRIPTION
## Summary

Add `$wgDefaultSkin = "vector-2022"` to `30-Vector.php`, moved from CanastaDefaultSettings.php. This makes the default skin user-configurable - users can change or remove it by editing or deleting this file.

## Related PRs

- CanastaWiki/CanastaBase#63 - Remove Vector skin loading from CanastaDefaultSettings.php

## Merge Order

Both PRs should be merged together. Merging CanastaBase first would result in no default skin until the DockerCompose change is deployed.