### PR TITLE
Improve Caddyfile architecture and fix Varnish startup race

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -3,6 +3,8 @@
 # Except this file
 !.gitignore
 !composer.local.json
+!Caddyfile
 !Caddyfile.custom
+!Caddyfile.global
 !default.vcl
 !SettingsTemplate.php

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -1,3 +1,4 @@
-{$MW_SITE_FQDN}:{$HTTPS_PORT}
-
-reverse_proxy varnish:80
+{$MW_SITE_FQDN} {
+    import /etc/caddy/Caddyfile.custom
+    reverse_proxy varnish:80
+}

--- a/config/Caddyfile.global
+++ b/config/Caddyfile.global
@@ -1,0 +1,9 @@
+# Global Caddy options for this Canasta installation.
+# This file is imported inside the global options block of the
+# auto-generated Caddyfile and is not overwritten by the CLI.
+#
+# Add global Caddy directives below. For example, to disable
+# automatic HTTPS (when SSL is terminated by an upstream proxy):
+#   auto_https off
+#
+# See https://caddyserver.com/docs/caddyfile/options for available options.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,10 +73,14 @@ services:
       - caddy-data:/data
       - ./config/Caddyfile:/etc/caddy/Caddyfile
       - ./config/Caddyfile.custom:/etc/caddy/Caddyfile.custom
+      - ./config/Caddyfile.global:/etc/caddy/Caddyfile.global
 
   varnish:
     image: docker.io/library/varnish:7.0.2-alpine
     restart: unless-stopped
+    depends_on:
+      web:
+        condition: service_healthy
     volumes:
        - ./config/default.vcl:/etc/varnish/default.vcl:ro
     tmpfs:


### PR DESCRIPTION
## Summary

- Update default Caddyfile: add `import Caddyfile.custom`, use explicit site block with curly braces, remove `{$HTTPS_PORT}` (container-internal ports are always 80/443)
- Add `Caddyfile.global` for user-managed global Caddy options (e.g. `auto_https off` for SSL termination upstream)
- Mount `Caddyfile.global` into Caddy container
- Add `depends_on` with `service_healthy` condition for Varnish on web service, preventing Varnish VCL compilation failure when `web` hostname isn't resolvable yet
- Add `Caddyfile` and `Caddyfile.global` to `config/.gitignore` exceptions

## Notes

- Corresponding CLI changes to `RewriteCaddy()` (supporting `Caddyfile.global`, `CADDY_AUTO_HTTPS` flag, etc.) will be tracked in a separate Canasta-CLI issue
- Non-CLI users who need SSL termination or wiki farm support should edit the Caddyfile manually (to be documented)

## Test plan

- [ ] Verify new installation with CLI generates correct Caddyfile with import directives
- [ ] Verify `Caddyfile.custom` directives are applied
- [ ] Verify Varnish starts successfully without DNS errors on fresh `docker compose up`
- [ ] Verify non-CLI usage with default Caddyfile works for single-wiki HTTPS

Partially addresses #84 (DockerCompose side only; CLI changes to follow)