### PR TITLE
Add global options block to default Caddyfile

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -1,3 +1,7 @@
+{
+    import /etc/caddy/Caddyfile.global
+}
+
 {$MW_SITE_FQDN} {
     import /etc/caddy/Caddyfile.custom
     reverse_proxy varnish:80


### PR DESCRIPTION
## Summary

- Add global options block with `import /etc/caddy/Caddyfile.global`
- Matches the Caddyfile structure generated by the CLI

Fixes #88