### PR TITLE
Remove MYSQL_DATABASE=mediawiki from db service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     environment:
       - MYSQL_ROOT_HOST=%
       - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_DATABASE=mediawiki
     volumes:
       - ./_initdb:/docker-entrypoint-initdb.d
       - mysql-data-volume:/var/lib/mysql


### PR DESCRIPTION
## Summary

Closes #93.

Canasta creates databases via `install.php` using wiki IDs from `wikis.yaml`. The hardcoded `MYSQL_DATABASE=mediawiki` causes MySQL to create an empty `mediawiki` database on first startup that is never used by any wiki.

## Test plan

- [ ] Create a new Canasta installation and verify databases are created correctly via `install.php`
- [ ] Verify no empty `mediawiki` database is created